### PR TITLE
Assign addresses before readEni()

### DIFF
--- a/doc/examples/simple4/main.zig
+++ b/doc/examples/simple4/main.zig
@@ -15,7 +15,9 @@ pub fn main() !void {
     try port.ping(10000);
 
     var scanner = gcat.Scanner.init(&port, .{});
-    try scanner.busInit(10_000_000, try scanner.countSubdevices());
+    const nsubdevices = try scanner.countSubdevices();
+    try scanner.busInit(10_000_000, nsubdevices);
+    try scanner.assignStationAddresses(nsubdevices);
     const eni = try scanner.readEni(
         gpa.allocator(),
         10_000_000,


### PR DESCRIPTION
Without scanner.assignStationAddresses() before, scanner.readEni() fails with `ReadFailed`.

After the EtherCAT node is powered up, `simple4` always fails with `ReadFailed`. If I run a `gatorcat scan ...`, `simple4` starts working as expected (and it always does). A power down/power up cycle restores the initial condition.

By inspecting the CLI code, I found a call to `assignStationAddress()` is present in `gatorcat scan` but absent in `simple4`. No idea what that does, but including that call in `simple4` seems to fix the issue. 

<details>
<summary>Here is the simple4 output capturing the ReadFailed error</summary>

```
debug(gatorcat): scanning ENI for subdevice at position: 0
error: ReadFailed
/home/nicola/bazar/gatorcat/src/module/Port.zig:536:30: 0x11df266 in fpwrPackWkc__anon_32607 (root.zig)
    if (wkc != expected_wkc) return error.Wkc;
                             ^
/home/nicola/bazar/gatorcat/src/module/sii.zig:913:22: 0x11cca6f in readSII4ByteFP (root.zig)
        error.Wkc => return error.Timeout,
                     ^
/home/nicola/bazar/gatorcat/src/module/sii.zig:860:30: 0x11b5b9b in stream (root.zig)
            error.Timeout => return error.ReadFailed,
                             ^
/usr/lib/zig/std/Io/Reader.zig:405:21: 0x1068d06 in defaultReadVec (std.zig)
        else => |e| return e,
                    ^
/usr/lib/zig/std/Io/Reader.zig:374:33: 0x11ce4e6 in readVec (std.zig)
            error.ReadFailed => return error.ReadFailed,
                                ^
/usr/lib/zig/std/Io/Reader.zig:633:33: 0x11b6b01 in readSliceShort (std.zig)
            error.ReadFailed => return error.ReadFailed,
                                ^
/usr/lib/zig/std/Io/Reader.zig:604:15: 0x119419d in readSliceAll (std.zig)
    const n = try readSliceShort(r, buffer);
              ^
/home/nicola/bazar/gatorcat/src/module/sii.zig:810:29: 0x1193c28 in readSIIFP_ps__anon_23303 (root.zig)
        error.ReadFailed => return error.ReadFailed,
                            ^
/home/nicola/bazar/gatorcat/src/module/Scanner.zig:313:18: 0x1177ccb in readSubdeviceConfigurationLeaky (root.zig)
    const info = try sii.readSIIFP_ps(
                 ^
/home/nicola/bazar/gatorcat/src/module/Scanner.zig:270:24: 0x117fff0 in readEniLeaky (root.zig)
        const config = try self.readSubdeviceConfigurationLeaky(
                       ^
/home/nicola/bazar/gatorcat/src/module/Scanner.zig:250:18: 0x1180827 in readEni (root.zig)
        .value = try self.readEniLeaky(
                 ^
/home/nicola/bazar/gatorcat/doc/examples/simple4/main.zig:19:17: 0x118daa4 in main (main.zig)
    const eni = try scanner.readEni(
                ^
```
</details>